### PR TITLE
Sum before dividing

### DIFF
--- a/tensor.apl
+++ b/tensor.apl
@@ -4,9 +4,9 @@ scores ← 2 3 ⍴ 95 83 76 99 89 82
 ≡ scores
 ≡ (95 83 76) (99 89 82)
 
-rowMean ← {+⌿⍵÷≢⍵}
+rowMean ← {(+⌿⍵)÷≢⍵}
 colMean ← {rowMean ⍉⍵}
-axisMean ← {+/[⍺]⍵÷⍺⌷⍴⍵}
+axisMean ← {(+/[⍺]⍵)÷⍺⌷⍴⍵}
 
 rowMean scores
 colMean scores


### PR DESCRIPTION
`+⌿⍵÷≢⍵` is `+⌿(⍵÷≢⍵)` i.e. all elements of the array are divided by the number of rows, before summing the columns. This can potentially lead to worse floating point precision, and certainly impacts performance negatively, needing *n* × *m* divisions and (*n* − 1) × *m* (float) additions whereas `(+⌿⍵)÷≢⍵` only needs *m* divisions and (*n* − 1) × *m* (integer) additions.